### PR TITLE
fix: Fix how we load the XBlock settings for lms.env.json

### DIFF
--- a/tutorhastexo/patches/lms-env
+++ b/tutorhastexo/patches/lms-env
@@ -1,4 +1,2 @@
 "ADDL_INSTALLED_APPS": ["hastexo"],
-"XBLOCK_SETTINGS": {
-    "hastexo": {{ HASTEXO_XBLOCK_SETTINGS|tojson(indent=4) }}
-}
+"XBLOCK_SETTINGS": {{ HASTEXO_XBLOCK_SETTINGS|tojson(indent=2) }}


### PR DESCRIPTION
Including the settings key "hastexo" in the patch to lms-env
breaks the indentation for the overall xblock settings.

Instead, expect the settings key to be provided together with the
settings in config.yml.

Use indent=2 to match the settings to the rest of the lms.env.json
file.