### PR TITLE
build: Add version information to images

### DIFF
--- a/tutorhastexo/plugin.py
+++ b/tutorhastexo/plugin.py
@@ -1,3 +1,4 @@
+from .__about__ import __version__
 from glob import glob
 import os
 import pkg_resources
@@ -13,8 +14,9 @@ config = {
         "SECRET_KEY": "{{ 50|random_string }}",
     },
     "defaults": {
+        "VERSION": __version__,
         "GUACD_DOCKER_IMAGE": "guacamole/guacd:1.4.0",
-        "DOCKER_IMAGE": "hastexo",
+        "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}hastexo:{{ HASTEXO_VERSION }}",
         "XBLOCK_VERSION": "stable",
         "DEBUG": False,
     }

--- a/tutorhastexo/templates/version
+++ b/tutorhastexo/templates/version
@@ -1,0 +1,1 @@
+{{ HASTEXO_VERSION }}


### PR DESCRIPTION
By redefining the default for `HASTEXO_DOCKER_IMAGE` to include `HASTEXO_VERSION`, our images get tagged with the version string defined therein. By setting this to the version of the plugin, we get new image names every time we bump a release. This allows us to create a new image whenever we put a new release out, and use that image name in rolling upgrades.

Also, following the precedent set by other plugins ([like tutor-mfe](https://github.com/overhangio/tutor-mfe/blob/master/tutormfe/plugin.py#L13)), include `DOCKER_REGISTRY` in the default as well. That way, we can use a local Docker registry for custom images (by setting `DOCKER_REGISTRY`), while retaining automatic version tagging (by leaving `HASTEXO_DOCKER_IMAGE` unset).