### PR TITLE
Refactor, fix and update settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Unreleased
   so that the `XBLOCK_SETTINGS` will be present in the
   `hastexo` container and thus, will make it possible to
   define custom settings for the terminal window.
+* Add support for installing custom fonts for terminal.
+  The required font will have to be installed in the
+  `guacd` container. Add an option to build a custom
+  `guacd` image while keeping the option of using the
+  upstream base image in case a custom font is not needed.
 
 ## Version 0.0.2 (2022-02-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+-----------------------------
+
+* Refactor the way we add `HASTEXO_XBLOCK_SETTINGS` to the
+  `XBLOCK_SETTINGS`. Add the settings under the `hastexo` key
+  without overriding the general definition.
+
 ## Version 0.0.2 (2022-02-25)
 
 * Fix version number as it appears in pip list (previously, all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Unreleased
 * Refactor the way we add `HASTEXO_XBLOCK_SETTINGS` to the
   `XBLOCK_SETTINGS`. Add the settings under the `hastexo` key
   without overriding the general definition.
+* Fix terminal customisation options. Override the default
+  settings module for the `hastexo_guacamole_client`
+  so that the `XBLOCK_SETTINGS` will be present in the
+  `hastexo` container and thus, will make it possible to
+  define custom settings for the terminal window.
 
 ## Version 0.0.2 (2022-02-25)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,30 @@ Configuration
   [guacd](https://hub.docker.com/r/guacamole/guacd) version. (default:
   `guacamole/guacd:1.4.0`)
 
+Using a custom terminal font
+----------------------------
+
+When using the `terminal_font_name` setting via `HASTEXO_XBLOCK_SETTINGS`,
+the requested font *must be installed in the guacd container*. This means that you'll
+need to build a custom `guacd` image. For that:
+* Define the `HASTEXO_GUACD_DOCKER_IMAGE` in your `config.yml` to override using the
+  default upstream image.
+* Create a YAML plugin to patch [hastexo-guacd-dockerfile]() and add your font installation
+  steps. For example:
+  ```
+  name: guacdfonts
+  version: 1.0.0
+  patches:
+    hastexo-guacd-dockerfile: |
+      USER root
+      RUN apt update && apt install -y fonts-hack-ttf
+  ```
+* Enable the YAML plugin and save your configuration changes (`tutor config save`)
+* Build the custom docker image for `guacd`:
+  ```
+  tutor images build guacd
+  ```
+
 License
 -------
 

--- a/tutorhastexo/patches/k8s-deployments
+++ b/tutorhastexo/patches/k8s-deployments
@@ -122,15 +122,13 @@ spec:
           ports:
             - containerPort: 8095
           env:
-            - name: HASTEXO_GUACAMOLE_SECRET_KEY
-              value: '{{ HASTEXO_SECRET_KEY }}'
-            - name: HASTEXO_GUACAMOLE_DEFAULT_DB_NAME
-              value: '{{ OPENEDX_MYSQL_DATABASE }}'
-            - name: HASTEXO_GUACAMOLE_DATABASE_USER
-              value: '{{ OPENEDX_MYSQL_USERNAME }}'
-            - name: HASTEXO_GUACAMOLE_DATABASE_PASSWORD
-              value: '{{ OPENEDX_MYSQL_PASSWORD }}'
-            - name: HASTEXO_GUACAMOLE_DATABASE_HOST
-              value: '{{  MYSQL_HOST }}'
-            - name: HASTEXO_GUACAMOLE_DATABASE_PORT
-              value: '{{ MYSQL_PORT }}'
+            - name: DJANGO_SETTINGS_MODULE
+              value: hastexo_guacamole_client.tutor.settings
+          volumeMounts:
+            - mountPath: /hastexo-xblock/hastexo_guacamole_client/tutor/settings.py
+              name: settings
+              subPath: settings.py
+      volumes:
+        - name: settings
+          configMap:
+            name: hastexo-settings

--- a/tutorhastexo/patches/kustomization-configmapgenerator
+++ b/tutorhastexo/patches/kustomization-configmapgenerator
@@ -1,0 +1,3 @@
+- name: hastexo-settings
+  files:
+    - plugins/hastexo/apps/hastexo/settings/settings.py

--- a/tutorhastexo/patches/lms-env
+++ b/tutorhastexo/patches/lms-env
@@ -1,4 +1,0 @@
-"ADDL_INSTALLED_APPS": ["hastexo"],
-"XBLOCK_SETTINGS": {
-    "hastexo": {{ HASTEXO_XBLOCK_SETTINGS|tojson(indent=4) }}
-}

--- a/tutorhastexo/patches/local-docker-compose-services
+++ b/tutorhastexo/patches/local-docker-compose-services
@@ -8,17 +8,13 @@ guacd:
 ############# hastexo-guacamole-client
 hastexo-xblock:
   image: {{ HASTEXO_DOCKER_IMAGE }}
+  environment:
+    DJANGO_SETTINGS_MODULE: hastexo_guacamole_client.tutor.settings
   restart: unless-stopped
   ports:
     - 8095:8095
-  environment:
-    - HASTEXO_GUACAMOLE_DEBUG={{ HASTEXO_DEBUG }}
-    - HASTEXO_GUACAMOLE_SECRET_KEY={{ HASTEXO_SECRET_KEY }}
-    - HASTEXO_GUACAMOLE_DEFAULT_DB_NAME={{ OPENEDX_MYSQL_DATABASE }}
-    - HASTEXO_GUACAMOLE_DATABASE_USER={{ OPENEDX_MYSQL_USERNAME }}
-    - HASTEXO_GUACAMOLE_DATABASE_PASSWORD={{ OPENEDX_MYSQL_PASSWORD }}
-    - HASTEXO_GUACAMOLE_DATABASE_HOST={{ MYSQL_HOST }}
-    - HASTEXO_GUACAMOLE_DATABASE_PORT={{ MYSQL_PORT }}
+  volumes:
+    - ../plugins/hastexo/apps/hastexo/settings:/hastexo-xblock/hastexo_guacamole_client/tutor:ro
   depends_on:
     - guacd
     - mysql

--- a/tutorhastexo/patches/openedx-common-settings
+++ b/tutorhastexo/patches/openedx-common-settings
@@ -1,0 +1,2 @@
+XBLOCK_SETTINGS["hastexo"] = {{ HASTEXO_XBLOCK_SETTINGS }}
+INSTALLED_APPS.append("hastexo")

--- a/tutorhastexo/plugin.py
+++ b/tutorhastexo/plugin.py
@@ -15,7 +15,9 @@ config = {
     },
     "defaults": {
         "VERSION": __version__,
-        "GUACD_DOCKER_IMAGE": "guacamole/guacd:1.4.0",
+        "GUACD_VERSION": "1.4.0",
+        "GUACD_BASE_IMAGE": "guacamole/guacd:{{ HASTEXO_GUACD_VERSION }}",
+        "GUACD_DOCKER_IMAGE": "{{ HASTEXO_GUACD_BASE_IMAGE }}",
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}hastexo:{{ HASTEXO_VERSION }}",
         "XBLOCK_VERSION": "stable",
         "DEBUG": False,
@@ -24,10 +26,12 @@ config = {
 
 hooks = {
     "build-image": {
-        "hastexo": "{{ HASTEXO_DOCKER_IMAGE }}"
+        "hastexo": "{{ HASTEXO_DOCKER_IMAGE }}",
+        "guacd": "{{ HASTEXO_GUACD_DOCKER_IMAGE }}",
     },
     "remote-image": {
-        "hastexo": "{{ HASTEXO_DOCKER_IMAGE }}"
+        "hastexo": "{{ HASTEXO_DOCKER_IMAGE }}",
+        "guacd": "{{ HASTEXO_GUACD_DOCKER_IMAGE }}",
     }
 }
 

--- a/tutorhastexo/templates/hastexo/apps/hastexo/settings/settings.py
+++ b/tutorhastexo/templates/hastexo/apps/hastexo/settings/settings.py
@@ -1,0 +1,63 @@
+import json
+import os
+
+from distutils.util import strtobool
+
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+SECRET_KEY = "{{ HASTEXO_SECRET_KEY }}"
+DEBUG = bool(strtobool("{{ HASTEXO_DEBUG }}"))
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'default': {
+            'format': '%(levelname)s:%(name)s:%(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'DEBUG' if DEBUG else 'WARNING'
+    },
+}
+
+ALLOWED_HOSTS = ''
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': "{{ OPENEDX_MYSQL_DATABASE }}",
+        'USER': "{{ OPENEDX_MYSQL_USERNAME }}",
+        'PASSWORD': "{{ OPENEDX_MYSQL_PASSWORD }}",
+        'HOST': "{{ MYSQL_HOST }}",
+        'PORT': "{{ MYSQL_PORT }}",
+        'ATOMIC_REQUESTS': False,
+        'CONN_MAX_AGE': 0,
+        'OPTIONS': {},
+    }
+}
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'channels',
+    'hastexo_guacamole_client'
+]
+
+ASGI_APPLICATION = 'hastexo_guacamole_client.routing:application'
+
+XBLOCK_SETTINGS = {
+    "hastexo": json.loads(
+        """{{ HASTEXO_XBLOCK_SETTINGS | tojson(indent=4) }}""")
+}

--- a/tutorhastexo/templates/hastexo/build/guacd/Dockerfile
+++ b/tutorhastexo/templates/hastexo/build/guacd/Dockerfile
@@ -1,0 +1,4 @@
+ARG HASTEXO_GUACD_VERSION={{ HASTEXO_GUACD_VERSION }}
+FROM guacamole/guacd:$HASTEXO_GUACD_VERSION
+
+{{ patch("hastexo-guacd-dockerfile") }}


### PR DESCRIPTION
- refactor: XBLOCK_SETTINGS

    Refactor the way we add HASTEXO_XBLOCK_SETTINGS to the
    XBLOCK_SETTINGS. Add the settings under the "hastexo" key
    without overriding the general definition.
    Append "hastexo" straight to INSTALLED_APPS and drop
    the definition of "ADDL_INSTALLED_APPS".

- fix: terminal customisation options

    Override the default settings module for the `hastexo_guacamole_client`
    so that the `XBLOCK_SETTINGS` will be present in the `hastexo`
    container and thus, will make it possible to define custom settings
    for the terminal window.

- feat: Add support for installing custom terminal fonts

    Add support for installing custom fonts for terminal.
    The required font will have to be installed in the
    `guacd` container. Add an option to build a custom
    `guacd` image while keeping the option of using the
    upstream base image in case a custon font is not needed.