### PR TITLE
refactor: Use Tutor v1 plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+-----------------------------
+* Use Tutor v1 plugin API
+
+
 Version 0.2.0 (2022-06-28)
 -----------------------------
 * Add `HASTEXO_ENABLE_SUSPENDER` and `HASTEXO_ENABLE_REAPER` to

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor<14"],
+    install_requires=["tutor <14, >=13.2.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
-        "tutor.plugin.v0": [
+        "tutor.plugin.v1": [
             "hastexo = tutorhastexo.plugin"
         ]
     },


### PR DESCRIPTION
Tutor v1 plugin API was introduces in Tutor 13.2.0. Refactor the plugin
to use the v1 API instead of the legacy v0 API.

Reference: https://github.com/overhangio/cookiecutter-tutor-plugin#migrating-from-v0-plugins