### PR TITLE
feat: Support running the `hastexo_guacamole_client` with Channels 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+-----------------------------
+* Make `ASGI_APPLICATION` configurable and add `LMS_HOST` to
+  `ALLOWED_HOSTS` to support running the `hastexo_guacamole_client`
+  with Channels 3.
+
 Version 0.3.0 (2022-06-29)
 -----------------------------
 * Use Tutor v1 plugin API

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Configuration
   If `False`, run 0 pods, effectively disabling the deployment. (Default: `True`).
 * `HASTEXO_ENABLE_REAPER`: If `True`, run 1 pod in the `hastexo-xblock-reaper` deployment. 
   If `False`, run 0 pods, effectively disabling the deployment. (Default: `True`).
+* `HASTEXO_ASGI_APPLICATION`: Definition for the asgi application,
+  added for backwards compatibility. For the hastexo-xblock<7,
+  set this to `hastexo_guacamole_client.routing:application`, for newer versions, use the default.
+  (Default: `hastexo_guacamole_client.asgi:application`)
 
 Using a custom terminal font
 ----------------------------

--- a/tutorhastexo/plugin.py
+++ b/tutorhastexo/plugin.py
@@ -20,7 +20,8 @@ config = {
         "DEBUG": False,
         "REPLICA_COUNT": 1,
         "ENABLE_REAPER": True,
-        "ENABLE_SUSPENDER": True
+        "ENABLE_SUSPENDER": True,
+        "ASGI_APPLICATION": "hastexo_guacamole_client.asgi:application"
     }
 }
 

--- a/tutorhastexo/templates/hastexo/apps/hastexo/settings/settings.py
+++ b/tutorhastexo/templates/hastexo/apps/hastexo/settings/settings.py
@@ -28,7 +28,7 @@ LOGGING = {
     },
 }
 
-ALLOWED_HOSTS = ''
+ALLOWED_HOSTS = ["{{ LMS_HOST }}"]
 
 DATABASES = {
     'default': {
@@ -55,7 +55,7 @@ INSTALLED_APPS = [
     'hastexo_guacamole_client'
 ]
 
-ASGI_APPLICATION = 'hastexo_guacamole_client.routing:application'
+ASGI_APPLICATION = '{{ HASTEXO_ASGI_APPLICATION }}'
 
 XBLOCK_SETTINGS = {
     "hastexo": json.loads(

--- a/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
+++ b/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
@@ -2,9 +2,10 @@ FROM python:3.8
 ENV PYTHONUNBUFFERED 1
 ARG HASTEXO_XBLOCK_GIT_REPOSITORY=https://github.com/hastexo/hastexo-xblock.git
 ARG HASTEXO_XBLOCK_VERSION={{ HASTEXO_XBLOCK_VERSION }}
+ARG HASTEXO_ASGI_APPLICATION={{ HASTEXO_ASGI_APPLICATION }}
 RUN git clone $HASTEXO_XBLOCK_GIT_REPOSITORY -b $HASTEXO_XBLOCK_VERSION ./hastexo-xblock
 WORKDIR ./hastexo-xblock
 RUN pip install --upgrade pip && \
     pip install -r requirements/base.txt --exists-action w
 EXPOSE 8095
-CMD daphne -b 0.0.0.0 -p 8095 hastexo_guacamole_client.routing:application
+CMD daphne -b 0.0.0.0 -p 8095 $HASTEXO_ASGI_APPLICATION


### PR DESCRIPTION
Make the `ASGI_APPLICATION` for the `hastexo_guacamole_client` configurable
for backwards compatibility but set the default to point to the newer version.

Add the LMS_HOST to ALLOWED_HOSTS as the updated asgi application uses
the list to validate incoming connections.