### PR TITLE
fix: Fix the ASGI_APPLICATION definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Unreleased
 -----------------------------
-* Make `ASGI_APPLICATION` configurable and add `LMS_HOST` to
-  `ALLOWED_HOSTS` to support running the `hastexo_guacamole_client`
-  with Channels 3.
+* BREAKING CHANGE: Update the `ASGI_APPLICATION` definition and
+   add `LMS_HOST` to `ALLOWED_HOSTS` to support running the 
+   `hastexo_guacamole_client` with Channels 3.
 
 Version 0.3.0 (2022-06-29)
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -79,10 +79,6 @@ Configuration
   If `False`, run 0 pods, effectively disabling the deployment. (Default: `True`).
 * `HASTEXO_ENABLE_REAPER`: If `True`, run 1 pod in the `hastexo-xblock-reaper` deployment. 
   If `False`, run 0 pods, effectively disabling the deployment. (Default: `True`).
-* `HASTEXO_ASGI_APPLICATION`: Definition for the asgi application,
-  added for backwards compatibility. For the hastexo-xblock<7,
-  set this to `hastexo_guacamole_client.routing:application`, for newer versions, use the default.
-  (Default: `hastexo_guacamole_client.asgi:application`)
 
 Using a custom terminal font
 ----------------------------

--- a/tutorhastexo/plugin.py
+++ b/tutorhastexo/plugin.py
@@ -21,7 +21,6 @@ config = {
         "REPLICA_COUNT": 1,
         "ENABLE_REAPER": True,
         "ENABLE_SUSPENDER": True,
-        "ASGI_APPLICATION": "hastexo_guacamole_client.asgi:application"
     }
 }
 

--- a/tutorhastexo/templates/hastexo/apps/hastexo/settings/settings.py
+++ b/tutorhastexo/templates/hastexo/apps/hastexo/settings/settings.py
@@ -55,7 +55,7 @@ INSTALLED_APPS = [
     'hastexo_guacamole_client'
 ]
 
-ASGI_APPLICATION = '{{ HASTEXO_ASGI_APPLICATION }}'
+ASGI_APPLICATION = 'hastexo_guacamole_client.asgi:application'
 
 XBLOCK_SETTINGS = {
     "hastexo": json.loads(

--- a/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
+++ b/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
@@ -2,10 +2,9 @@ FROM python:3.8
 ENV PYTHONUNBUFFERED 1
 ARG HASTEXO_XBLOCK_GIT_REPOSITORY=https://github.com/hastexo/hastexo-xblock.git
 ARG HASTEXO_XBLOCK_VERSION={{ HASTEXO_XBLOCK_VERSION }}
-ARG HASTEXO_ASGI_APPLICATION={{ HASTEXO_ASGI_APPLICATION }}
 RUN git clone $HASTEXO_XBLOCK_GIT_REPOSITORY -b $HASTEXO_XBLOCK_VERSION ./hastexo-xblock
 WORKDIR ./hastexo-xblock
 RUN pip install --upgrade pip && \
     pip install -r requirements/base.txt --exists-action w
 EXPOSE 8095
-CMD daphne -b 0.0.0.0 -p 8095 $HASTEXO_ASGI_APPLICATION
+CMD daphne -b 0.0.0.0 -p 8095 hastexo_guacamole_client.asgi:application


### PR DESCRIPTION
Back out of making the `ASGI_APPLICATION` configurable, as the argument
will not be passed properly during image build and Daphne will not run.

Update the value instead and keep it as a breaking change.