### PR TITLE
build: Version 1.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 tag = True
 sign_tags = True
 message = build: Version {new_version}
-current_version = 0.3.0
+current_version = 1.0.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 1.0.0 (2022-08-19)
 -----------------------------
 
 * BREAKING CHANGE: Support Tutor 14 and Open edX Nutmeg. This entails


### PR DESCRIPTION
As of this release, the plugin supports Tutor v14 and hence Open edX Nutmeg.