### PR TITLE
feat: Update guacd version default to 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+-----------------------------
+
+* Bump the default guacd version from 1.4.0 to 1.5.2.
+
 Version 1.1.0 (2023-03-20)
 -----------------------------
 * Add support for Open edX Olive.

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Configuration
   `{}`)
 * `HASTEXO_XBLOCK_VERSION`: The Hastexo XBlock version. (default:
   `stable`)
+* `HASTEXO_GUACD_VERSION`: [guacd version](https://guacamole.apache.org/releases/) (default: `1.5.2`)
 * `HASTEXO_GUACD_DOCKER_IMAGE`:
-  [guacd](https://hub.docker.com/r/guacamole/guacd) version. (default:
-  `guacamole/guacd:1.4.0`)
+  [guacd](https://hub.docker.com/r/guacamole/guacd) Docker image version. (default:
+  `guacamole/guacd:1.5.2`)
 * `HASTEXO_REPLICA_COUNT`: Number of replicas for the `hastexo-xblock` service.
   (default: `1`)
 * `HASTEXO_ENABLE_SUSPENDER`: If `True`, run 1 pod in the `hastexo-xblock-suspender` deployment. 

--- a/tutorhastexo/plugin.py
+++ b/tutorhastexo/plugin.py
@@ -12,7 +12,7 @@ config = {
     },
     "defaults": {
         "VERSION": __version__,
-        "GUACD_VERSION": "1.4.0",
+        "GUACD_VERSION": "1.5.2",
         "GUACD_BASE_IMAGE": "guacamole/guacd:{{ HASTEXO_GUACD_VERSION }}",
         "GUACD_DOCKER_IMAGE": "{{ HASTEXO_GUACD_BASE_IMAGE }}",
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}hastexo:{{ HASTEXO_VERSION }}",


### PR DESCRIPTION
Guacamole 1.5.0 introduced the ability to connect to SSH servers using elliptic-curve keys (in addition to RSA), which is a requirement for connecting to sshd servers that have phased out RSA key support.

Since then, two interim release have followed to address issues reported with the Docker images.

Update the default for `HASTEXO_GUACD_VERSION` from 1.4.0 to 1.5.2, and also update the `README` and changelog.

References:
https://guacamole.apache.org/releases/
https://guacamole.apache.org/releases/1.5.0/#release-notes
https://guacamole.apache.org/releases/1.5.2/#release-notes