### PR TITLE
fix: Fix installing the hastexo XBlock for version >=7.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------------------------
+* [Bug fix] Install the Hastexo XBlock code in the right context
+  (in the current directory).
+
 Version 1.5.0 (2024-04-05)
 ----------------------------
 * [Enhancement] Support Python 3.12.

--- a/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
+++ b/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
@@ -5,6 +5,9 @@ ARG HASTEXO_XBLOCK_VERSION={{ HASTEXO_XBLOCK_VERSION }}
 RUN git clone $HASTEXO_XBLOCK_GIT_REPOSITORY -b $HASTEXO_XBLOCK_VERSION ./hastexo-xblock
 WORKDIR ./hastexo-xblock
 RUN pip install --upgrade pip && \
-    pip install -r requirements/base.txt --exists-action w
+    # install the XBlock in editable mode until we add support for the next Open edX release,
+    # to avoid introducing a breaking change within the supported versions of this
+    # plugin and the Hastexo XBlock for the Quince release.
+    pip install -r requirements/base.txt --exists-action w -e .
 EXPOSE 8095
 CMD daphne -b 0.0.0.0 -p 8095 hastexo_guacamole_client.asgi:application


### PR DESCRIPTION
In the latest changes to the XBlock(v7.10.1) we dropped the "-e ." in `requirements/base.txt`; we still need to install the code in the current directory for this plugin so we need to add the "." in the Dockerfile.

For backward compatibility, install the code still in editable mode within the Quince release.