### PR TITLE
feat: Add support for Tutor 18 / Open edX Redwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+----------------------------
+* [Enhancement] Support Tutor 18 and Open edX Redwood.
+
 Version 1.5.1 (2024-04-30)
 ----------------------------
 * [Bug fix] Install the Hastexo XBlock code in the right context

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ appropriate one:
 |------------------|-------------------|------------------------|---------------|----------------|
 | Lilac            | `>=12.0, <13`     | Not supported          | Not supported | Not supported  |
 | Maple            | `>=13.2, <14`[^1] | `>=6.0, <7.0`          | `maple`       | 0.3.x          |
-| Nutmeg           | `>=14.0, <15`     | `>=7.0`                | `main`        | 1.x.x          |
-| Olive            | `>=15.0, <16`     | `>=7.0`                | `main`        | 1.x.x          |
-| Palm             | `>=16.0, <17`     | `>=7.0`                | `main`        | 1.x.x          |
-| Quince           | `>=17.0, <18`     | `>=7.0`                | `main`        | 1.x.x          |
+| Nutmeg           | `>=14.0, <15`     | `>=7.0, <7.12`         | `quince`      | `>=1.0, <1.6`  |
+| Olive            | `>=15.0, <16`     | `>=7.0, <7.12`         | `quince`      | `>=1.0, <1.6`  |
+| Palm             | `>=16.0, <17`     | `>=7.0, <7.12`         | `quince`      | `>=1.0, <1.6`  |
+| Quince           | `>=17.0, <18`     | `>=7.0, <7.12`         | `quince`      | `>=1.0, <1.6`  |
+| Redwood          | `>=18.0, <19`     | `>=7.12.0`             | `main`        | `>=1.6.x`      |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <18, >=14.0.0"],
+    install_requires=["tutor <19, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [

--- a/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
+++ b/tutorhastexo/templates/hastexo/build/hastexo/Dockerfile
@@ -5,9 +5,6 @@ ARG HASTEXO_XBLOCK_VERSION={{ HASTEXO_XBLOCK_VERSION }}
 RUN git clone $HASTEXO_XBLOCK_GIT_REPOSITORY -b $HASTEXO_XBLOCK_VERSION ./hastexo-xblock
 WORKDIR ./hastexo-xblock
 RUN pip install --upgrade pip && \
-    # install the XBlock in editable mode until we add support for the next Open edX release,
-    # to avoid introducing a breaking change within the supported versions of this
-    # plugin and the Hastexo XBlock for the Quince release.
-    pip install -r requirements/base.txt --exists-action w -e .
+    pip install -r requirements/base.txt --exists-action w .
 EXPOSE 8095
 CMD daphne -b 0.0.0.0 -p 8095 hastexo_guacamole_client.asgi:application


### PR DESCRIPTION
* Update the install_requires list to support Tutor 18.
* Update the compatibility matrix in the README accordingly.