### PR TITLE
docs: Reformat Markdown files according to CommonMark specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,110 +1,87 @@
-Version 2.4.0 (2026-01-23)
-----------------------------
+# Version 2.4.0 (2026-01-23)
 
 * [Enhancement] Support Tutor 21 and Open edX Ulmo.
 
-Version 2.3.1 (2026-01-16)
-----------------------------
+# Version 2.3.1 (2026-01-16)
 
 * Point release to mark the GitHub repository move.
 
-Version 2.3.0 (2025-07-28)
-----------------------------
+# Version 2.3.0 (2025-07-28)
+
 * [Enhancement] Support Tutor 20 and Open edX Teak.
 
-Version 2.2.0 (2025-04-15)
-----------------------------
+# Version 2.2.0 (2025-04-15)
+
 * [Enhancement] Allow to override the Dockerfile base image.
 
-Version 2.1.0 (2025-01-03)
-----------------------------
+# Version 2.1.0 (2025-01-03)
+
 * Bump the default `guacd` version.
 * Support Tutor 19 and Open edX Sumac.
 
-Version 2.0.0 (2024-10-07)
-----------------------------
+# Version 2.0.0 (2024-10-07)
+
 * Drop support for Python 3.8.
 
 When updating your plugin to this version, you'll need to rebuild the image.
 
-Version 1.6.0 (2024-08-07)
-----------------------------
+# Version 1.6.0 (2024-08-07)
+
 * [Enhancement] Support Tutor 18 and Open edX Redwood.
 
-Version 1.5.1 (2024-04-30)
-----------------------------
-* [Bug fix] Install the Hastexo XBlock code in the right context
-  (in the current directory).
+# Version 1.5.1 (2024-04-30)
 
-Version 1.5.0 (2024-04-05)
-----------------------------
+* [Bug fix] Install the Hastexo XBlock code in the right context (in the current directory).
+
+# Version 1.5.0 (2024-04-05)
+
 * [Enhancement] Support Python 3.12.
 
-Version 1.4.0 (2024-01-12)
-----------------------------
+# Version 1.4.0 (2024-01-12)
+
 * [Enhancement] Support Tutor 17 and Open edX Quince.
 
 ## Version 1.3.0 (2023-08-21)
 
 * [Enhancement] Support Tutor 16 and Open edX Palm, Python 3.10, and Python 3.11.
 
-Version 1.2.0 (2023-06-28)
------------------------------
+# Version 1.2.0 (2023-06-28)
 
 * Bump the default guacd version from 1.4.0 to 1.5.2.
 
-Version 1.1.0 (2023-03-20)
------------------------------
+# Version 1.1.0 (2023-03-20)
+
 * Add support for Open edX Olive.
 
-Version 1.0.0 (2022-08-19)
------------------------------
+# Version 1.0.0 (2022-08-19)
 
-* BREAKING CHANGE: Support Tutor 14 and Open edX Nutmeg. This entails
-  a configuration format change from JSON to YAML, meaning that from
-  version 1.0.0 this plugin only supports Tutor versions from 14.0.0
-  (and with that, only Open edX versions from Nutmeg).
+* BREAKING CHANGE: Support Tutor 14 and Open edX Nutmeg.
+  This entails a configuration format change from JSON to YAML, meaning that from version 1.0.0 this plugin only supports Tutor versions from 14.0.0 (and with that, only Open edX versions from Nutmeg).
 
-* BREAKING CHANGE: Update the `ASGI_APPLICATION` definition and
-   add `LMS_HOST` to `ALLOWED_HOSTS` to support running the 
-   `hastexo_guacamole_client` with Channels 3.
+* BREAKING CHANGE: Update the `ASGI_APPLICATION` definition and add `LMS_HOST` to `ALLOWED_HOSTS` to support running the `hastexo_guacamole_client` with Channels 3.
 
-Version 0.3.0 (2022-06-29)
------------------------------
+# Version 0.3.0 (2022-06-29)
+
 * Use Tutor v1 plugin API
 
+# Version 0.2.0 (2022-06-28)
 
-Version 0.2.0 (2022-06-28)
------------------------------
-* Add `HASTEXO_ENABLE_SUSPENDER` and `HASTEXO_ENABLE_REAPER` to
-  effectively enable/disable the `suspender` and `reaper` deployments
-  (by setting their respective replica counts to 1 or 0).
-* Add an option to scale the number of instances via
-  `HASTEXO_REPLICA_COUNT` setting.
+* Add `HASTEXO_ENABLE_SUSPENDER` and `HASTEXO_ENABLE_REAPER` to effectively enable/disable the `suspender` and `reaper` deployments (by setting their respective replica counts to 1 or 0).
+* Add an option to scale the number of instances via `HASTEXO_REPLICA_COUNT` setting.
 
-Version 0.1.0 (2022-04-20)
------------------------------
+# Version 0.1.0 (2022-04-20)
 
-* Refactor the way we add `HASTEXO_XBLOCK_SETTINGS` to the
-  `XBLOCK_SETTINGS`. Add the settings under the `hastexo` key
-  without overriding the general definition.
-* Fix terminal customisation options. Override the default
-  settings module for the `hastexo_guacamole_client`
-  so that the `XBLOCK_SETTINGS` will be present in the
-  `hastexo` container and thus, will make it possible to
-  define custom settings for the terminal window.
+* Refactor the way we add `HASTEXO_XBLOCK_SETTINGS` to the `XBLOCK_SETTINGS`.
+  Add the settings under the `hastexo` key without overriding the general definition.
+* Fix terminal customisation options.
+  Override the default settings module for the `hastexo_guacamole_client` so that the `XBLOCK_SETTINGS` will be present in the `hastexo` container and thus, will make it possible to define custom settings for the terminal window.
 * Add support for installing custom fonts for terminal.
-  The required font will have to be installed in the
-  `guacd` container. Add an option to build a custom
-  `guacd` image while keeping the option of using the
-  upstream base image in case a custom font is not needed.
+  The required font will have to be installed in the `guacd` container.
+  Add an option to build a custom `guacd` image while keeping the option of using the upstream base image in case a custom font is not needed.
 
 ## Version 0.0.2 (2022-02-25)
 
-* Fix version number as it appears in pip list (previously, all
-  installations would show up as version 0.0.0, including
-  installations from the 0.0.1 tag).
-
+* Fix version number as it appears in pip list (previously, all installations would show up as version 0.0.0, including installations from the 0.0.1 tag).
 
 ## Version 0.0.1 (2022-02-24)
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,14 @@
-Tutor plugin for the [Hastexo Guacamole Client](https://github.com/cleura/hastexo-xblock/tree/master/hastexo_guacamole_client)
-===============================================
+# Tutor plugin for the [Hastexo Guacamole Client](https://github.com/cleura/hastexo-xblock/tree/master/hastexo_guacamole_client)
 
-
-This is a plugin for [Tutor](https://docs.tutor.overhang.io) that
-deploys the [Hastexo Guacamole
-Client](https://github.com/cleura/hastexo-xblock/tree/master/hastexo_guacamole_client)
-application alongside Open edX.  Using this plugin is neccessary for
-running the [Hastexo
-XBlock](https://github.com/cleura/hastexo-xblock) in your Tutor Open
-edX platform.
+This is a plugin for [Tutor](https://docs.tutor.overhang.io) that deploys the [Hastexo Guacamole Client](https://github.com/cleura/hastexo-xblock/tree/master/hastexo_guacamole_client) application alongside Open edX.
+Using this plugin is necessary for running the [Hastexo XBlock](https://github.com/cleura/hastexo-xblock) in your Tutor Open edX platform.
 
 This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
 
-Version compatibility matrix
-----------------------------
+## Version compatibility matrix
 
-You must install a supported release of this plugin to match the Open
-edX and Tutor version you are deploying. If you are installing this
-plugin from a branch in this Git repository, you must select the
-appropriate one:
+You must install a supported release of this plugin to match the Open edX and Tutor version you are deploying.
+If you are installing this plugin from a branch in this Git repository, you must select the appropriate one:
 
 | Open edX release | Tutor version     | Hastexo XBlock version | Plugin branch | Plugin release |
 |------------------|-------------------|------------------------|---------------|----------------|
@@ -33,92 +23,70 @@ appropriate one:
 | Teak             | `>=20.0, <21`     | `>=7.12.0`             | `main`        | `>=2.3`        |
 | Ulmo             | `>=21.0, <22`     | `>=7.12.0`             | `main`        | `>=2.4`        |
 
-[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
-    later. That is because this plugin uses the Tutor v1 plugin API,
-    [which was introduced with that
-    release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
+[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or later.
+      That is because this plugin uses the Tutor v1 plugin API, [which was introduced with that release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
 
-Installation
-------------
+## Installation
 
-First of all, before installing this plugin, make sure you have
-installed the [Hastexo
-XBlock](https://github.com/cleura/hastexo-xblock) to your Open edX
-platform running with Tutor. For that, add the XBlock to your
-`OPENEDX_EXTRA_PIP_REQUIREMENTS` in `config.yml`:
+First of all, before installing this plugin, make sure you have installed the [Hastexo XBlock](https://github.com/cleura/hastexo-xblock) to your Open edX platform running with Tutor.
+For that, add the XBlock to your `OPENEDX_EXTRA_PIP_REQUIREMENTS` in `config.yml`:
 
-```
+```yaml
 OPENEDX_EXTRA_PIP_REQUIREMENTS:
 - git+https://github.com/cleura/hastexo-xblock.git
 ```
 
-rebuild the `openedx` docker image:
+Rebuild the `openedx` docker image:
 
-```
+```bash
 tutor images build openedx
 ```
 
-then upload the image to the registry of your choice, and set
-`DOCKER_IMAGE_OPENEDX` in your `config.yml` to reference that image.
+Then upload the image to the registry of your choice, and set `DOCKER_IMAGE_OPENEDX` in your `config.yml` to reference that image.
 
-For more information about installing XBlocks, please refer to the
-[Tutor documentation for installing
-XBlocks](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements)
-
+For more information about installing XBlocks, please refer to the [Tutor documentation for installing XBlocks](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).
 
 Then, to install this plugin, run:
 
-```
+```bash
 pip install git+https://github.com/cleura/tutor-contrib-hastexo@v2.4.0
 ```
 
 To enable this plugin, run:
 
-```
+```bash
 tutor plugins enable hastexo
 ```
 
-Before starting Tutor, build the docker image for the `hastexo`
-service:
+Before starting Tutor, build the docker image for the `hastexo` service:
 
-```
+```bash
 tutor images build hastexo
 ```
 
-then (as with the `openedx` image) upload the image to your preferred
-registry, and set `HASTEXO_DOCKER_IMAGE` to point to that image.
+Then (as with the `openedx` image) upload the image to your preferred registry, and set `HASTEXO_DOCKER_IMAGE` to point to that image.
 
-Configuration
--------------
+## Configuration
 
-* `HASTEXO_XBLOCK_SETTINGS`: The Hastexo XBlock settings, examples and
-  details provided in the [XBlock
-  README](https://github.com/cleura/hastexo-xblock#deployment). (default:
-  `{}`)
-* `HASTEXO_XBLOCK_VERSION`: The Hastexo XBlock version. (default:
-  `stable`)
+* `HASTEXO_XBLOCK_SETTINGS`: The Hastexo XBlock settings, examples and details provided in the [XBlock README](https://github.com/cleura/hastexo-xblock#deployment). (default: `{}`)
+* `HASTEXO_XBLOCK_VERSION`: The Hastexo XBlock version. (default: `stable`)
 * `HASTEXO_GUACD_VERSION`: [guacd version](https://guacamole.apache.org/releases/) (default: `1.5.2`)
-* `HASTEXO_GUACD_DOCKER_IMAGE`:
-  [guacd](https://hub.docker.com/r/guacamole/guacd) Docker image version. (default:
-  `guacamole/guacd:1.5.2`)
-* `HASTEXO_REPLICA_COUNT`: Number of replicas for the `hastexo-xblock` service.
-  (default: `1`)
-* `HASTEXO_ENABLE_SUSPENDER`: If `True`, run 1 pod in the `hastexo-xblock-suspender` deployment. 
+* `HASTEXO_GUACD_DOCKER_IMAGE`: [guacd](https://hub.docker.com/r/guacamole/guacd) Docker image version. (default: `guacamole/guacd:1.5.2`)
+* `HASTEXO_REPLICA_COUNT`: Number of replicas for the `hastexo-xblock` service. (default: `1`)
+* `HASTEXO_ENABLE_SUSPENDER`: If `True`, run 1 pod in the `hastexo-xblock-suspender` deployment.
   If `False`, run 0 pods, effectively disabling the deployment. (Default: `True`).
-* `HASTEXO_ENABLE_REAPER`: If `True`, run 1 pod in the `hastexo-xblock-reaper` deployment. 
+* `HASTEXO_ENABLE_REAPER`: If `True`, run 1 pod in the `hastexo-xblock-reaper` deployment.
   If `False`, run 0 pods, effectively disabling the deployment. (Default: `True`).
 
-Using a custom terminal font
-----------------------------
+## Using a custom terminal font
 
-When using the `terminal_font_name` setting via `HASTEXO_XBLOCK_SETTINGS`,
-the requested font *must be installed in the guacd container*. This means that you'll
-need to build a custom `guacd` image. For that:
-* Define the `HASTEXO_GUACD_DOCKER_IMAGE` in your `config.yml` to override using the
-  default upstream image.
-* Create a YAML plugin to patch [hastexo-guacd-dockerfile]() and add your font installation
-  steps. For example:
-  ```
+When using the `terminal_font_name` setting via `HASTEXO_XBLOCK_SETTINGS`, the requested font *must be installed in the guacd container*.
+This means that you'll need to build a custom `guacd` image.
+For that:
+
+* Define the `HASTEXO_GUACD_DOCKER_IMAGE` in your `config.yml` to override using the default upstream image.
+* Create a YAML plugin to patch `hastexo-guacd-dockerfile` and add your font installation steps. For example:
+  ```yaml
   name: guacdfonts
   version: 1.0.0
   patches:
@@ -128,11 +96,10 @@ need to build a custom `guacd` image. For that:
   ```
 * Enable the YAML plugin and save your configuration changes (`tutor config save`)
 * Build the custom docker image for `guacd`:
-  ```
+  ```bash
   tutor images build guacd
   ```
 
-License
--------
+## License
 
 This software is licensed under the terms of the AGPLv3.


### PR DESCRIPTION
- Use ATX headings instead of setext headings
- Use fenced code blocks with info strings
- Write one sentence per line outside code blocks
- Preserve existing bullet list markers

Assisted-by: opencode/qwen3-coder-30b

(This is effectively a test of the agentic coding instructions added in #52.)
