### PR TITLE
build: Be stricter about commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec tox -e gitlint -- --staged --msg-filename "$1" run-hook


### PR DESCRIPTION
Add a `commit-msg` hook to check the commit message with `gitlint`, and abort the commit if the commit message is unsatisfactory.
