### PR TITLE
Fix: Fix translations

### DIFF
--- a/tutorstackamole/patches/openedx-dockerfile-pre-assets
+++ b/tutorstackamole/patches/openedx-dockerfile-pre-assets
@@ -1,0 +1,4 @@
+RUN cp -a /openedx/venv/lib/python3.11/site-packages/stackamole/locale/. /openedx/edx-platform/conf/plugins-locale/xblock.v1/stackamole/
+
+RUN ./manage.py lms --settings=tutor.i18n compile_xblock_translations
+RUN ./manage.py lms --settings=tutor.i18n compilejsi18n


### PR DESCRIPTION
Patch the openedx Dockerfile to:
* Include the Stackamole XBlock translations by copying the files
  to /openedx/edx-platform/conf/plugins-locale/xblock.v1/stackamole/
  which is where the Atlas pulled translations would land.
* Rerun the compile_xblock_translations and compilejsi18n to
  compile the added translations.