### PR TITLE
build: Set skip_missing_interpreters = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* [Testing] Set skip_missing_interpreters = true for tox, so that it runs with whatever Python is available.
+
 # Version 3.1.0 (2026-06-16)
 
 * [Enhancement] Add support for Content Libraries v2.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = gitlint,py{39,310,311,312},flake8
+skip_missing_interpreters = true
 
 [gh-actions]
 python =


### PR DESCRIPTION
In tox 4.56, released on 2026-06-23, tox restored the 3.x behaviour (which it considers "correct") to fail on unavailable Python interpreters, rather than skipping them.

Override this changed default by setting
skip_missing_interpreters = true, so that tox runs with whatever Python is available.

References:
https://tox.wiki/en/latest/changelog.html#v4-56-0-2026-06-23 tox-dev/tox#3966